### PR TITLE
AB#560 Get ARM Token in  command, hides value from logs

### DIFF
--- a/.github/workflows/luis_ci.yaml
+++ b/.github/workflows/luis_ci.yaml
@@ -140,16 +140,11 @@ jobs:
       run: |
           az account show --query 'id' | \
           xargs -I {} echo "::set-env name=AzureSubscriptionId::{}"
-    
-    - name: Azure Get Access Token
-      run: |
-          az account get-access-token --query accessToken -o tsv  | \
-          xargs -I {} echo "::set-env name=arm_token::{}"
 
     - name: Assign LUIS Azure Prediction resource to application
       run: |
         curl POST $POSTurl \
-        -H "Authorization: Bearer $arm_token" \
+        -H "Authorization: Bearer $(az account get-access-token --query accessToken -o tsv)" \
         -H "Content-Type: application/json" \
         -H "Ocp-Apim-Subscription-Key: ${{ secrets.LUISAuthoringKey }}" \
         --data-ascii "{'AzureSubscriptionId': '$AzureSubscriptionId', 'ResourceGroup': '$AzureResourceGroup', 'AccountName': '$AzureLuisPredictionResourceName' }"


### PR DESCRIPTION
Call to az account get-access-token now embedded in curl command,  no longer stores ARM Token in environment variable.
Result is that the value is not revealed in GitHub Actions logs.

See step  **Assign LUIS Azure Prediction resource to application** in test run https://github.com/AndyCW/AndyLUISDevOpsSample/pull/28/checks?check_run_id=636069714 

Previously, the token was stored in an environment variable, but this meant that it was visible if you expanded the logging for steps after the env variable had been set. See https://github.com/AndyCW/AndyLUISDevOpsSample/runs/629423049?check_suite_focus=true , step  **Assign LUIS Azure Prediction resource to application**  for an example.