### PR TITLE
AB#557 AB#558 AB#559 AB#561 AB#570 Andycw/bug fixes

### DIFF
--- a/.github/workflows/luis_ci.yaml
+++ b/.github/workflows/luis_ci.yaml
@@ -78,9 +78,8 @@ jobs:
     - name: Install botframework-cli
       run: npm i -g @microsoft/botframework-cli
 
-    # Telemetry prompt botcli  bug - https://github.com/microsoft/botframework-cli/issues/370
-    - name: Disable botframework-cli telemetry
-      run: 'mkdir -p ~/.config/@microsoft/botframework-cli; echo "{ \"telemetry\": false }" > $_/config.json'
+    - name: Bypass botframework-cli telemetry prompts, enable telemetry collection - set to false to disable telemetry collection
+      run: echo "::set-env name=BF_CLI_TELEMETRY::true"
 
     - name: Ludown to LUIS model
       run: bf luis:convert -i $LU_FILE -o ./model.json --name 'LUIS CI pipeline - ${{ github.run_id }}' --versionid $luisAppVersion
@@ -150,11 +149,6 @@ jobs:
         --data-ascii "{'AzureSubscriptionId': '$AzureSubscriptionId', 'ResourceGroup': '$AzureResourceGroup', 'AccountName': '$AzureLuisPredictionResourceName' }"
       env:
         POSTurl: ${{ env.luisAuthoringEndpoint }}luis/authoring/v3.0-preview/apps/${{ env.AppId }}/azureaccounts
-        
-    - name: Get LUIS prediction region (for NLU.DevOps Test)
-      run: |
-          az cognitiveservices account show --name $AzureLuisPredictionResourceName --resource-group $AzureResourceGroup --query "location" | \
-          xargs -I {} echo "::set-env name=luisEndpointRegion::{}"
 
     - name: Test Luis model
       run: dotnet nlu test -s luisV3 -u $UNIT_TEST_FILE -o results.json
@@ -163,6 +157,7 @@ jobs:
         luisVersionId: ${{ env.luisAppVersion }}
         luisDirectVersionPublish: true        
         luisEndpointKey: ${{ secrets.LUISPredictionKey }}
+        luisPredictionResourceName: ${{ env.AzureLuisPredictionResourceName }}
 
     - name: Analyze Unit test results
       run: dotnet nlu compare -e $UNIT_TEST_FILE -a results.json --unit-test --output-folder unittest
@@ -208,10 +203,9 @@ jobs:
     - name: Install @microsoft/botframework-cli
       run: npm i -g @microsoft/botframework-cli
 
-    # Telemetry prompt botcli  bug - https://github.com/microsoft/botframework-cli/issues/370
-    - name: Disable botframework-cli telemetry
-      run: 'mkdir -p ~/.config/@microsoft/botframework-cli; echo "{ \"telemetry\": false }" > $_/config.json'
-    
+    - name: Bypass botframework-cli telemetry prompts, enable telemetry collection - set to false to disable telemetry collection
+      run: echo "::set-env name=BF_CLI_TELEMETRY::true"
+
     - name: Get master LUIS application ID
       run: |
         bf luis:application:list --subscriptionKey ${{ secrets.LUISAuthoringKey }} --endpoint $luisAuthoringEndpoint | \
@@ -230,11 +224,6 @@ jobs:
 
     - name: Add dotnet Tools to Path
       run: echo "::add-path::$HOME/.dotnet/tools"
-    
-    - name: Get LUIS prediction region (for NLU.DevOps Test)
-      run: |
-          az cognitiveservices account show --name $AzureLuisPredictionResourceName --resource-group $AzureResourceGroup --query "location" | \
-          xargs -I {} echo "::set-env name=luisEndpointRegion::{}"
 
     - name: Test Luis model with quality verification tests
       run: dotnet nlu test -s luisV3 -u $QUALITY_TEST_FILE -o F-results.json
@@ -244,6 +233,7 @@ jobs:
         luisVersionId: ${{ env.LuisVersion }}
         luisDirectVersionPublish: true
         luisEndpointKey: ${{ secrets.LUISPredictionKey }}
+        luisPredictionResourceName: ${{ env.AzureLuisPredictionResourceName }}
 
     - name: download baseline
       if: env.BASELINE_CONTAINER_NAME != ''
@@ -298,9 +288,8 @@ jobs:
     - name: Install @microsoft/botframework-cli
       run: npm i -g @microsoft/botframework-cli
 
-    # Telemetry prompt botcli  bug - https://github.com/microsoft/botframework-cli/issues/370
-    - name: Disable botframework-cli telemetry
-      run: 'mkdir -p ~/.config/@microsoft/botframework-cli; echo "{ \"telemetry\": false }" > $_/config.json'
+    - name: Bypass botframework-cli telemetry prompts, enable telemetry collection - set to false to disable telemetry collection
+      run: echo "::set-env name=BF_CLI_TELEMETRY::true"
 
     - name: Get LUIS authoring endpoint
       run: |

--- a/docs/2-feature-branches-and-running-pipelines.md
+++ b/docs/2-feature-branches-and-running-pipelines.md
@@ -49,7 +49,7 @@ If you followed the [setup instruction for this sample](../README.md) you will h
 
 ## Make your LUIS app updates
 
-Now that you are working inside the feature branch, you can make your updates to the LUIS app source, unit tests and model verification tests. If this was a brand new project, you would need to create the LUDown representation of the first version of your LUIS app and the JSON files for testing and check them in. We use the [LUDown format](https://github.com/microsoft/botbuilder-tools/tree/master/packages/Ludown#ludown) to define a LUIS app since it can be maintained in a source control system and is human readable which enables the reviewing process because of its legibility.
+Now that you are working inside the feature branch, you can make your updates to the LUIS app source, unit tests and model verification tests. If this was a brand new project, you would need to create the LUDown representation of the first version of your LUIS app and the JSON files for testing and check them in. We use the [LUDown format](https://github.com/microsoft/botframework-cli/blob/master/packages/luis/docs/lu-file-format.md) to define a LUIS app since it can be maintained in a source control system and is human readable which enables the reviewing process because of its legibility.
 
 In this sample, the LUDown for a sample application and the test files are provided:
 
@@ -190,6 +190,8 @@ If you click on the **Actions** tab immediately after you merge your pull reques
 ![CI/CD pipeline completed](images/cicdpipelinecompleted.png?raw=true "CI/CD pipeline completed")
 
 ### Verifying the new LUIS master app version
+
+> **Note:** This solution uses [GitVersion](https://gitversion.net/docs/why) to increment the version number on every build. It looks at your git history on every commit to calculate what the version currently is, and calculates the new version number automatically using semantic versioning. You can instruct GitVersion to manually increment the major, minor or patch version using commit messages, or by setting the next-version property in the GitVersion.yml file in the root of your repository. Read more about [GitVersion Version Incrementing](https://gitversion.net/docs/more-info/version-increments) in the GitVersion documentation.
 
 After the pipeline has completed successfully, if you look on the home page of your repository, you can see that a new release has been created:
 

--- a/docs/4-pipeline.md
+++ b/docs/4-pipeline.md
@@ -138,9 +138,8 @@ Next we install node.js (necessary for running the Bot Framework CLI) and the BF
       with:
         node-version: '12.x'
 
-    # Telemetry prompt botcli  bug - https://github.com/microsoft/botframework-cli/issues/370
-    - name: Disable botframework-cli telemetry
-      run: 'mkdir -p ~/.config/@microsoft/botframework-cli; echo "{ \"telemetry\": false }" > $_/config.json'
+    - name: Bypass botframework-cli telemetry prompts, enable telemetry collection - set to false to disable telemetry collection
+      run: echo "::set-env name=BF_CLI_TELEMETRY::true"
 
     - name: Install @microsoft/botframework-cli
       run: |
@@ -265,15 +264,6 @@ In order to test a LUIS app, you must use a Azure LUIS Prediction resource key s
 
   ```
 
-The NLU.DevOps test tool needs to have the prediction region set in an environment variable:
-
-  ```yml
-      - name: Get LUIS prediction region (for NLU.DevOps Test)
-      run: |
-          az cognitiveservices account show --name $AzureLuisPredictionResourceName --resource-group $AzureResourceGroup --query "location" | \
-          xargs -I {} echo "::set-env name=luisEndpointRegion::{}"
-  ```
-
 To test the LUIS app version that was created, we use the unit test file:
 
   ```yml
@@ -284,6 +274,7 @@ To test the LUIS app version that was created, we use the unit test file:
         luisVersionId: ${{ env.luisAppVersion }}
         luisDirectVersionPublish: true
         luisEndpointKey: ${{ secrets.LUISPredictionKey }}
+        luisPredictionResourceName: ${{ env.AzureLuisPredictionResourceName }}
   ```
 
 To evaluate results we use two files: the *unit test file* that consists of test utterances and the expected intents and entities results and `results.json` file which was created by the Test LUIS model step and contains the actual results returned from testing the LUIS model:
@@ -374,6 +365,7 @@ Testing uses the verification test file rather than the unit test file:
         luisVersionId: ${{ env.LuisVersion }}
         luisDirectVersionPublish: true
         luisEndpointKey: ${{ secrets.LUISPredictionKey }}
+        luisPredictionResourceName: ${{ env.AzureLuisPredictionResourceName }}
   ```
 
 #### Compare F measure results with baseline

--- a/setup/create_sp.ps1
+++ b/setup/create_sp.ps1
@@ -4,9 +4,7 @@ $spname = Read-Host "Enter the Service Principal name [$($SP_DEFAULT)]: "
 $spname = ($SP_DEFAULT,$spname)[[bool]$spname]
 
 # Get the resource group name
-$RG_DEFAULT="luisDevOpsRG"
-$resourceGroup = Read-Host "Enter the Azure Resource Group name [$($RG_DEFAULT)]: "
-$resourceGroup = ($RG_DEFAULT,$resourceGroup)[[bool]$resourceGroup]
+$resourceGroup = Read-Host "Enter the Azure Resource Group name: "
 
 # get our subscriptionId
 $subscriptionId=$(az account show --query id -o tsv)

--- a/setup/create_sp.sh
+++ b/setup/create_sp.sh
@@ -5,9 +5,7 @@ read -p "Enter the Service Principal name [$SP_DEFAULT]: " spname
 spname="${spname:-$SP_DEFAULT}"
 
 # Get the resource group name
-RG_DEFAULT="luisDevOpsRG"
-read -p "Enter the Azure Resource Group name [$RG_DEFAULT]: " resourceGroup
-resourceGroup="${resourceGroup:-$RG_DEFAULT}"
+read -p "Enter the Azure Resource Group name: " resourceGroup
 
 # get our subscriptionId
 subscriptionId=$(az account show --query id -o tsv)


### PR DESCRIPTION
Grab bag of bug fixes:
#557 Removed step to fetch prediction region, replaced with luisPredictionResourceName env vafriable for 'nlu test'.
#558 Docs update linking to GitVersion.
#559 Removed default resource group from the create_sp scripts since everyone will have their own RG name so a default makes no sense.
#561 Docs update: link explaining LUDown format changed to go to a page that has a better description.
#570 Removed the BF CLI telemetry workaround as latest release of BF CLI now supports env variable for suppressing telemetry prompts.