### PR TITLE
Fixes #44 Get LUIS keys at runtime AB#588

### DIFF
--- a/.github/workflows/luis_ci.yaml
+++ b/.github/workflows/luis_ci.yaml
@@ -66,6 +66,16 @@ jobs:
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+    - name: Get LUIS authoring key
+      run: |
+          az cognitiveservices account keys list --name $AzureLuisAuthoringResourceName --resource-group $AzureResourceGroup --query "key1" | \
+          xargs -I {} echo "::set-env name=LUISAuthoringKey::{}"
+
+    - name: Get LUIS prediction key
+      run: |
+          az cognitiveservices account keys list --name $AzureLuisPredictionResourceName --resource-group $AzureResourceGroup --query "key1" | \
+          xargs -I {} echo "::set-env name=LUISPredictionKey::{}"
+
     - name: Get LUIS authoring endpoint
       run: |
           az cognitiveservices account show --name $AzureLuisAuthoringResourceName --resource-group $AzureResourceGroup --query "endpoint" | \
@@ -88,15 +98,15 @@ jobs:
     - name: Create PR check LUIS application 
       if: github.event_name == 'pull_request'
       run: |
-        importResult=`bf luis:application:import --endpoint $luisAuthoringEndpoint --subscriptionKey ${{ secrets.LUISAuthoringKey }}  --in model.json`
+        importResult=`bf luis:application:import --endpoint $luisAuthoringEndpoint --subscriptionKey ${{ env.LUISAuthoringKey }}  --in model.json`
         echo "::set-env name=AppId::$(echo $(echo $importResult | cut -b 35-70))" 
 
     # When doing a merge to master, use the master LUIS app - create if necessary (soft fails if exists)
     - name: Get master LUIS application ID
       if: github.event_name == 'push'
       run: |
-        bf luis:application:create --name $LUIS_MASTER_APP_NAME --subscriptionKey ${{ secrets.LUISAuthoringKey }} --endpoint $luisAuthoringEndpoint --versionId=0.1
-        bf luis:application:list --subscriptionKey ${{ secrets.LUISAuthoringKey }} --endpoint $luisAuthoringEndpoint | \
+        bf luis:application:create --name $LUIS_MASTER_APP_NAME --subscriptionKey ${{ env.LUISAuthoringKey }} --endpoint $luisAuthoringEndpoint --versionId=0.1
+        bf luis:application:list --subscriptionKey ${{ env.LUISAuthoringKey }} --endpoint $luisAuthoringEndpoint | \
         jq -c '.[] | select(.name | . and contains('\"$LUIS_MASTER_APP_NAME\"')) | .id' | \
         xargs -I {} echo "::set-env name=AppId::{}"
         echo "Found LUIS app: $AppId"
@@ -105,7 +115,7 @@ jobs:
     # Current implementation prints error message and fails pipeline.
     - name: Check LUIS app version count
       run: |
-        version_count=$(bf luis:version:list --appId $AppId --endpoint $luisAuthoringEndpoint --subscriptionKey ${{ secrets.LUISAuthoringKey }} | jq 'length')
+        version_count=$(bf luis:version:list --appId $AppId --endpoint $luisAuthoringEndpoint --subscriptionKey ${{ env.LUISAuthoringKey }} | jq 'length')
         if [ $version_count -ge 100 ]; then
           echo "ERROR: LUIS app: $AppId version count will exceed 100. Delete unneeded versions before re-running pipeline"
           exit 1
@@ -114,17 +124,17 @@ jobs:
     # When doing a CI/CD run on push to master, we create a new version in an existing LUIS application 
     - name: Create new LUIS application version
       if: github.event_name == 'push'
-      run: bf luis:version:import --appId $AppId --endpoint $luisAuthoringEndpoint --subscriptionKey ${{ secrets.LUISAuthoringKey }} --in model.json
+      run: bf luis:version:import --appId $AppId --endpoint $luisAuthoringEndpoint --subscriptionKey ${{ env.LUISAuthoringKey }} --in model.json
 
     - name: Train luis
       shell: bash
-      run: bf luis:train:run --appId $AppId --versionId $luisAppVersion --endpoint $luisAuthoringEndpoint --subscriptionKey ${{ secrets.LUISAuthoringKey }} --wait
+      run: bf luis:train:run --appId $AppId --versionId $luisAppVersion --endpoint $luisAuthoringEndpoint --subscriptionKey ${{ env.LUISAuthoringKey }} --wait
 
     - name: Publish luis
       run: |
         curl POST $POSTurl \
         -H "Content-Type: application/json" \
-        -H "Ocp-Apim-Subscription-Key: ${{ secrets.LUISAuthoringKey }}" \
+        -H "Ocp-Apim-Subscription-Key: ${{ env.LUISAuthoringKey }}" \
         --data-ascii "{'versionId': '$luisAppVersion', 'directVersionPublish': true}" 
       env:
         POSTurl: ${{ env.luisAuthoringEndpoint }}luis/authoring/v3.0-preview/apps/${{ env.AppId }}/publish
@@ -145,7 +155,7 @@ jobs:
         curl POST $POSTurl \
         -H "Authorization: Bearer $(az account get-access-token --query accessToken -o tsv)" \
         -H "Content-Type: application/json" \
-        -H "Ocp-Apim-Subscription-Key: ${{ secrets.LUISAuthoringKey }}" \
+        -H "Ocp-Apim-Subscription-Key: ${{ env.LUISAuthoringKey }}" \
         --data-ascii "{'AzureSubscriptionId': '$AzureSubscriptionId', 'ResourceGroup': '$AzureResourceGroup', 'AccountName': '$AzureLuisPredictionResourceName' }"
       env:
         POSTurl: ${{ env.luisAuthoringEndpoint }}luis/authoring/v3.0-preview/apps/${{ env.AppId }}/azureaccounts
@@ -156,7 +166,7 @@ jobs:
         luisAppId: ${{ env.AppId }}
         luisVersionId: ${{ env.luisAppVersion }}
         luisDirectVersionPublish: true        
-        luisEndpointKey: ${{ secrets.LUISPredictionKey }}
+        luisEndpointKey: ${{ env.LUISPredictionKey }}
         luisPredictionResourceName: ${{ env.AzureLuisPredictionResourceName }}
 
     - name: Analyze Unit test results
@@ -172,7 +182,7 @@ jobs:
     - name: Delete luis test target app
       if: always() && (github.event_name == 'pull_request')
       shell: bash
-      run:  bf luis:application:delete --appId $AppId --endpoint $luisAuthoringEndpoint --subscriptionKey ${{ secrets.LUISAuthoringKey }} --force
+      run:  bf luis:application:delete --appId $AppId --endpoint $luisAuthoringEndpoint --subscriptionKey ${{ env.LUISAuthoringKey }} --force
 
 
   # Job: LUIS quality testing
@@ -191,6 +201,16 @@ jobs:
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+    - name: Get LUIS authoring key
+      run: |
+          az cognitiveservices account keys list --name $AzureLuisAuthoringResourceName --resource-group $AzureResourceGroup --query "key1" | \
+          xargs -I {} echo "::set-env name=LUISAuthoringKey::{}"
+  
+    - name: Get LUIS prediction key
+      run: |
+          az cognitiveservices account keys list --name $AzureLuisPredictionResourceName --resource-group $AzureResourceGroup --query "key1" | \
+          xargs -I {} echo "::set-env name=LUISPredictionKey::{}"
+
     - name: Get LUIS authoring endpoint
       run: |
           az cognitiveservices account show --name $AzureLuisAuthoringResourceName --resource-group $AzureResourceGroup --query "endpoint" | \
@@ -208,14 +228,14 @@ jobs:
 
     - name: Get master LUIS application ID
       run: |
-        bf luis:application:list --subscriptionKey ${{ secrets.LUISAuthoringKey }} --endpoint $luisAuthoringEndpoint | \
+        bf luis:application:list --subscriptionKey ${{ env.LUISAuthoringKey }} --endpoint $luisAuthoringEndpoint | \
         jq -c '.[] | select(.name | . and contains('\"$LUIS_MASTER_APP_NAME\"')) | .id' | \
         xargs -I {} echo "::set-env name=AppId::{}"
         echo "Found LUIS app: $AppId"
 
     - name: Get LUIS latest version ID
       run: |
-        bf luis:version:list --appId $AppId --endpoint $luisAuthoringEndpoint --subscriptionKey ${{ secrets.LUISAuthoringKey }} --take 1 | \
+        bf luis:version:list --appId $AppId --endpoint $luisAuthoringEndpoint --subscriptionKey ${{ env.LUISAuthoringKey }} --take 1 | \
         jq '.[0].version' | \
         xargs -I {} echo "::set-env name=LuisVersion::{}"
 
@@ -232,7 +252,7 @@ jobs:
         luisAppId: ${{ env.AppId }} 
         luisVersionId: ${{ env.LuisVersion }}
         luisDirectVersionPublish: true
-        luisEndpointKey: ${{ secrets.LUISPredictionKey }}
+        luisEndpointKey: ${{ env.LUISPredictionKey }}
         luisPredictionResourceName: ${{ env.AzureLuisPredictionResourceName }}
 
     - name: download baseline
@@ -291,6 +311,11 @@ jobs:
     - name: Bypass botframework-cli telemetry prompts, enable telemetry collection - set to false to disable telemetry collection
       run: echo "::set-env name=BF_CLI_TELEMETRY::true"
 
+    - name: Get LUIS authoring key
+      run: |
+          az cognitiveservices account keys list --name $AzureLuisAuthoringResourceName --resource-group $AzureResourceGroup --query "key1" | \
+          xargs -I {} echo "::set-env name=LUISAuthoringKey::{}"
+
     - name: Get LUIS authoring endpoint
       run: |
           az cognitiveservices account show --name $AzureLuisAuthoringResourceName --resource-group $AzureResourceGroup --query "endpoint" | \
@@ -298,14 +323,14 @@ jobs:
 
     - name: Get master LUIS application ID
       run: |
-        bf luis:application:list --subscriptionKey ${{ secrets.LUISAuthoringKey }} --endpoint $luisAuthoringEndpoint | \
+        bf luis:application:list --subscriptionKey ${{ env.LUISAuthoringKey }} --endpoint $luisAuthoringEndpoint | \
         jq -c '.[] | select(.name | . and contains('\"$LUIS_MASTER_APP_NAME\"')) | .id' | \
         xargs -I {} echo "::set-env name=AppId::{}"
         echo "Found LUIS app: $AppId"
 
     - name: Get LUIS latest version ID
       run: |
-        bf luis:version:list --appId $AppId --endpoint $luisAuthoringEndpoint --subscriptionKey ${{ secrets.LUISAuthoringKey }} --take 1 --out luis_latest_version.json
+        bf luis:version:list --appId $AppId --endpoint $luisAuthoringEndpoint --subscriptionKey ${{ env.LUISAuthoringKey }} --take 1 --out luis_latest_version.json
         cat luis_latest_version.json | jq '.[0].version' | \
         xargs -I {} echo "::set-env name=LuisVersion::{}"
       

--- a/docs/1-project-setup.md
+++ b/docs/1-project-setup.md
@@ -14,7 +14,6 @@ In order to use this template to setup a repo for your own use, you will:
 - [Setup the CI/CD pipeline](#setup-the-ci/cd-pipeline)
   - [Set environment variables in the pipeline yaml](#set-environment-variables-for-resource-names-in-the-pipeline-yaml))
   - [Create the Azure Service Principal](#create-the-azure-service-principal)
-  - [Store LUIS Keys in GitHub Secrets](#store-luis-keys-in-github-secrets)
 - [Protect the master branch](#protecting-the-master-branch)
 
 ## Get the code
@@ -148,33 +147,6 @@ You need to configure an Azure Service Principal to allow the pipeline to login 
    You access GitHub Secrets by clicking on the **Settings** tab on the home page of your repository, or by going to `https://github.com/{your-GitHub-Id}/{your-repository}/settings`. Then click on **Secrets** in the **Options** menu, which brings up the UI for entering Secrets, like this:
 
    ![GitHub Secrets](./images/gitHubSecretsAzure.png?raw=true "Saving in GitHub Secrets")
-
-### Store LUIS Keys in GitHub Secrets
-
-You must also save the LUIS Authoring and Prediction resource keys in GitHub Secrets so that the pipeline can use them.
-
-You can get the keys using the Azure CLI, specifying the Azure Resource Group name and the LUIS resource names you entered when you configured them in Azure.  If multiple keys are returned for any resource, you can use any one of them.
-
-**LUIS Authoring**
-
-<code>
-az cognitiveservices account keys list --name <i>{LUISAuthoringResourceName}</i> --resource-group <i>{ResourceGroup}</i>
-</code>
-
-**LUIS Prediction**
-
-<code>
-az cognitiveservices account keys list --name <i>{LUISPredictionResourceName}</i> --resource-group <i>{ResourceGroup}</i>
-</code>
-
-Save these keys in **GitHub Secrets** in your repository, using the following key names:
-
-| Key                      |         value                     |
-|--------------------------|-----------------------------------|
-| **LUISAuthoringKey**     |  The LUIS Authoring resource key  |
-| **LUISPredictionKey**    |  The LUIS Prediction resource key |  
-
-![LUIS resource keys saved in GitHub Secrets](./images/saveGitHubSecretsLUIS.png?raw=true "Saving the LUIS resource keys in GitHub Secrets")
 
 ## Protecting the master branch
 


### PR DESCRIPTION
Add steps to luis_ci.yaml to fetch the LUIS Authoring Key and the Prediction Key at runtime and store in env variables.
Because they have 'key' in the variable name, GHA automagically masks the value (handy).
Update all subsequent sterps to get keys from env variables instead of secrets.

Remove the setup documentation about fetching the keys from Azure and storing them in GitHub Secrets.
Update the Pipeline.md to describe new steps.

See https://github.com/AndyCW/AndyLUISDevOpsSample/runs/666883036?check_suite_focus=true for a sample run using these updates.

Fixes #44 