### PR TITLE
Workaround for bf luis:train:run --wait

### DIFF
--- a/.github/workflows/luis_ci.yaml
+++ b/.github/workflows/luis_ci.yaml
@@ -58,13 +58,13 @@ jobs:
 
     - name: Get LUIS authoring key
       run: |
-         keya=$(az cognitiveservices account keys list --name ${{ secrets.AZURE_LUIS_AUTHORING_RESOURCE_NAME }} --resource-group $AzureResourceGroup --query "key1" | xargs)
+         keya=$(az cognitiveservices account keys list --name ${{ secrets.AZURE_LUIS_AUTHORING_RESOURCE_NAME }} --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} --query "key1" | xargs)
          echo "::set-env name=LUISAuthoringKey::$keya"
          echo "::add-mask::$keya"
 
     - name: Get LUIS prediction key
       run: |
-         keyp=$(az cognitiveservices account keys list --name ${{ secrets.AZURE_LUIS_PREDICTION_RESOURCE_NAME }} --resource-group $AzureResourceGroup --query "key1" | xargs)
+         keyp=$(az cognitiveservices account keys list --name ${{ secrets.AZURE_LUIS_PREDICTION_RESOURCE_NAME }} --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} --query "key1" | xargs)
          echo "::set-env name=LUISPredictionKey::$keyp"
          echo "::add-mask::$keyp"
 
@@ -110,8 +110,23 @@ jobs:
       run: bf luis:version:import --appId $LUISAppId --endpoint $LUISAuthoringEndpoint --subscriptionKey $LUISAuthoringKey  --in model.json
 
     - name: Train luis
-      shell: bash
-      run: bf luis:train:run --appId $LUISAppId --versionId $LUISAppVersion --endpoint $LUISAuthoringEndpoint --subscriptionKey $LUISAuthoringKey  --wait
+      run: bf luis:train:run --appId $LUISAppId --versionId $LUISAppVersion --endpoint $LUISAuthoringEndpoint --subscriptionKey $LUISAuthoringKey
+
+    - name: Wait for train
+      run: |
+        while true
+        do 
+          status=`bf luis:version:list --appId $LUISAppId --endpoint $LUISAuthoringEndpoint --subscriptionKey $LUISAuthoringKey |  jq '.[] | select(.version == '\"$LUISAppVersion\"') | .trainingStatus' | xargs`
+          if [ "$status" == "Trained" ]
+          then
+            break
+          elif [ "$status" == "Failed" ]
+          then
+            exit 1
+          fi
+          echo 'sleep 10'
+          sleep 10
+        done 
 
     - name: Publish luis
       run: |

--- a/.github/workflows/luis_pr.yaml
+++ b/.github/workflows/luis_pr.yaml
@@ -69,7 +69,23 @@ jobs:
         jq '.id' | xargs -I {} echo "::set-env name=LUISAppId::{}"
         
     - name: Train luis
-      run: bf luis:train:run --appId $LUISAppId --versionId 0.1 --endpoint $LUISAuthoringEndpoint --subscriptionKey $LUISAuthoringKey --wait
+      run: bf luis:train:run --appId $LUISAppId --versionId 0.1 --endpoint $LUISAuthoringEndpoint --subscriptionKey $LUISAuthoringKey
+
+    - name: Wait for train
+      run: |
+        while true
+        do 
+          status=`bf luis:version:list --appId $LUISAppId --endpoint $LUISAuthoringEndpoint --subscriptionKey $LUISAuthoringKey |  jq '.[] | select(.version == "0.1") | .trainingStatus' | xargs`
+          if [ "$status" == "Trained" ]
+          then
+            break
+          elif [ "$status" == "Failed" ]
+          then
+            exit 1
+          fi
+          echo 'sleep 10'
+          sleep 10
+        done 
 
     - name: Publish luis
       run: bf luis:application:publish --appId $LUISAppId --versionId 0.1 --endpoint $LUISAuthoringEndpoint --subscriptionKey $LUISAuthoringKey

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,7 @@
         "dataset",
         "devops",
         "docx",
+        "elif",
         "eval",
         "exportlu",
         "githubsecretsall",


### PR DESCRIPTION
Fixes #41 Workaround while --wait cannot be used. Loop and poll version training status.

See https://github.com/AndyCW/AndyLUISDevOpsSample/runs/686567310?check_suite_focus=true for sample run.